### PR TITLE
Remove incorrect note about multiple channels

### DIFF
--- a/data/docs/alerts-management/notification-channel/email.mdx
+++ b/data/docs/alerts-management/notification-channel/email.mdx
@@ -18,12 +18,6 @@ To manage your alert channels in SigNoz:
 
 ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Creating a new Notification channel
 To create a new Email notification channel in SigNoz, follow these steps:
 

--- a/data/docs/alerts-management/notification-channel/ms-teams.mdx
+++ b/data/docs/alerts-management/notification-channel/ms-teams.mdx
@@ -26,12 +26,6 @@ To manage your alert channels in SigNoz:
 
 ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Creating a new Notification channel
 
 - Navigate to `Settings > Alert Channels` and click on `New Channel`.

--- a/data/docs/alerts-management/notification-channel/opsgenie.mdx
+++ b/data/docs/alerts-management/notification-channel/opsgenie.mdx
@@ -18,12 +18,6 @@ To manage your alert channels in SigNoz:
 
 ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Creating a new Notification channel
 To create a new Opsgenie notification channel in SigNoz, follow these steps:
 

--- a/data/docs/alerts-management/notification-channel/pagerduty.mdx
+++ b/data/docs/alerts-management/notification-channel/pagerduty.mdx
@@ -24,12 +24,6 @@ To manage your alert channels in SigNoz:
 
    ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Obtaining Integration or Routing key 
 
 ### For Global Event Orchestration

--- a/data/docs/alerts-management/notification-channel/slack.mdx
+++ b/data/docs/alerts-management/notification-channel/slack.mdx
@@ -17,12 +17,6 @@ To manage your alert channels in SigNoz:
 
 ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Creating a new Notification channel
 
 To create a new Slack notification channel in SigNoz, follow these steps:

--- a/data/docs/alerts-management/notification-channel/webhook.mdx
+++ b/data/docs/alerts-management/notification-channel/webhook.mdx
@@ -22,12 +22,6 @@ To manage your alert channels in SigNoz:
 
 ![alert-channels](/img/docs/alert-channels.webp)
 
-<Admonition type="info">
-
-When multiple channels are set up, alerts will be sent to all the configured channels.
-
-</Admonition>
-
 ## Creating a new Webhook channel
 To create a new Webhook notification channel in SigNoz, follow these steps:
 


### PR DESCRIPTION
Setting up multiple channels doesn't send notifications to all channels. When creating an alert, the user should explicitly select the option to send to all channels.