### PR TITLE
minor: remove comment from the otel-collector config

### DIFF
--- a/components/shared/otel-binary-cloud-config.md
+++ b/components/shared/otel-binary-cloud-config.md
@@ -48,14 +48,12 @@ extensions:
   health_check: {}
   zpages: {}
 exporters:
-// highlight-start
   otlp:
     endpoint: "ingest.{region}.signoz.cloud:443"
     tls:
       insecure: false
     headers:
       "signoz-access-token": "<SIGNOZ_INGESTION_KEY>"
-// highlight-end
   logging:
     verbosity: normal
 service:


### PR DESCRIPTION
- Ideally the yaml supports '#' as a comment. Any user who is trying to copy the config file will face errors caused due to bad character. 